### PR TITLE
dynamic values in mi-image-pull podspecs

### DIFF
--- a/e2e/fixtures/mi-pull-image.yaml
+++ b/e2e/fixtures/mi-pull-image.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   nodeName: secrets-virtual-kubelet
   containers:
-  - image: acivirtualnodetestregistry.azurecr.io/alpine
+  - image: $CONTAINER_IMAGE
     imagePullPolicy: Always
     name: e2etest-acr-test-mi-container
     command: [ "/bin/sh" ]
@@ -24,7 +24,7 @@ metadata:
 spec:
   nodeName: nosecrets-virtual-kubelet
   containers:
-  - image: acivirtualnodetestregistry.azurecr.io/alpine
+  - image: $CONTAINER_IMAGE
     imagePullPolicy: Always
     name: e2etest-acr-test-mi-container
     command: [ "/bin/sh" ]


### PR DESCRIPTION
In order to integrate build variables in E2E test, this two things are needed:
  - create container registry with alpine image in aks.sh
  - integrate the variables in deployments_test.go